### PR TITLE
투표 여부에 관계없이 결과화면으로 가지는 현상 수정

### DIFF
--- a/app/src/main/java/com/example/onetouchpromise/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/onetouchpromise/ui/HomeScreen.kt
@@ -132,13 +132,17 @@ fun HomeScreen(
                         )
                     }
                     else -> {
+                        val userNotFoundError = stringResource(R.string.user_not_found)
+
                         MeetingListView(
                             meetings = uiState.meetings,
                             onMeetingClick = { meeting ->
-                                if(viewModel.checkUserVoted(currentUser!!.email)) {
-                                    onMeetingClick(Pair(true, meeting))
-                                } else {
-                                    onMeetingClick(Pair(false, meeting))
+                                try {
+                                    val currentUserEmail = currentUser?.email
+                                    val isAlreadyVoted = meeting.alreadyVotes.contains(currentUserEmail)
+                                    onMeetingClick(Pair(isAlreadyVoted, meeting))
+                                } catch (e: NullPointerException) {
+                                    viewModel.updateError(userNotFoundError)
                                 }
                             }
                         )

--- a/app/src/main/java/com/example/onetouchpromise/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/onetouchpromise/viewmodel/HomeViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import com.example.domain.model.MeetingModel
 import com.example.domain.model.UserModel
 import com.example.domain.usecase.GetCurrentUserUserCase
 import com.example.domain.usecase.ObserveHomeMeetingsUseCase
@@ -49,19 +50,12 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun checkUserVoted(
-        userEmail: String
-    ): Boolean {
-        val votedUserList = mutableSetOf<String>()
-        for(meeting in uiState.meetings) {
-            votedUserList.addAll(meeting.alreadyVotes)
-        }
-
-        return votedUserList.contains(userEmail)
-    }
-
     fun getCurrentUSer(): UserModel? {
         return getCurrentUserUserCase()
+    }
+
+    fun updateError(message: String) {
+        uiState = uiState.copy(error = message)
     }
 
     override fun onCleared() {


### PR DESCRIPTION
원인: 모든 모임의 참여자를 기준으로 구분하고 있었기에 현재 사용자가 어떤 하나의 모임에 투표를 진행했다면 다른 모임에서도 투표를 한 것으로 구분됨.
대책: 클릭한 모임을 기준으로 투표 여부를 확인하여 정상 동작하도록 수정